### PR TITLE
Skip audio transcode during process and use Matroska as media container format instead of MP4

### DIFF
--- a/cores/add.py
+++ b/cores/add.py
@@ -127,4 +127,4 @@ def addmosaic_video(opt,netS):
     ffmpeg.image2video( fps,
                         opt.temp_dir+'/addmosaic_image/output_%06d.'+opt.tempimage_type,
                         opt.temp_dir+'/voice_tmp.mkv',
-                         os.path.join(opt.result_dir,os.path.splitext(os.path.basename(path))[0]+'_add.mp4'))
+                         os.path.join(opt.result_dir,os.path.splitext(os.path.basename(path))[0]+'_add.mkv'))

--- a/cores/add.py
+++ b/cores/add.py
@@ -126,5 +126,5 @@ def addmosaic_video(opt,netS):
     print('Step:4/4 -- Convert images to video')
     ffmpeg.image2video( fps,
                         opt.temp_dir+'/addmosaic_image/output_%06d.'+opt.tempimage_type,
-                        opt.temp_dir+'/voice_tmp.mp3',
+                        opt.temp_dir+'/voice_tmp.mkv',
                          os.path.join(opt.result_dir,os.path.splitext(os.path.basename(path))[0]+'_add.mp4'))

--- a/cores/clean.py
+++ b/cores/clean.py
@@ -153,7 +153,7 @@ def cleanmosaic_video_byframe(opt,netG,netM):
     ffmpeg.image2video( fps,
                 opt.temp_dir+'/replace_mosaic/output_%06d.'+opt.tempimage_type,
                 opt.temp_dir+'/voice_tmp.mkv',
-                 os.path.join(opt.result_dir,os.path.splitext(os.path.basename(path))[0]+'_clean.mp4'))  
+                 os.path.join(opt.result_dir,os.path.splitext(os.path.basename(path))[0]+'_clean.mkv'))
 
 def cleanmosaic_video_fusion(opt,netG,netM):
     path = opt.media_path
@@ -246,4 +246,4 @@ def cleanmosaic_video_fusion(opt,netG,netM):
     ffmpeg.image2video( fps,
                 opt.temp_dir+'/replace_mosaic/output_%06d.'+opt.tempimage_type,
                 opt.temp_dir+'/voice_tmp.mkv',
-                 os.path.join(opt.result_dir,os.path.splitext(os.path.basename(path))[0]+'_clean.mp4')) 
+                 os.path.join(opt.result_dir,os.path.splitext(os.path.basename(path))[0]+'_clean.mkv'))

--- a/cores/clean.py
+++ b/cores/clean.py
@@ -152,7 +152,7 @@ def cleanmosaic_video_byframe(opt,netG,netM):
     print('Step:4/4 -- Convert images to video')
     ffmpeg.image2video( fps,
                 opt.temp_dir+'/replace_mosaic/output_%06d.'+opt.tempimage_type,
-                opt.temp_dir+'/voice_tmp.mp3',
+                opt.temp_dir+'/voice_tmp.mkv',
                  os.path.join(opt.result_dir,os.path.splitext(os.path.basename(path))[0]+'_clean.mp4'))  
 
 def cleanmosaic_video_fusion(opt,netG,netM):
@@ -245,5 +245,5 @@ def cleanmosaic_video_fusion(opt,netG,netM):
     print('Step:4/4 -- Convert images to video')
     ffmpeg.image2video( fps,
                 opt.temp_dir+'/replace_mosaic/output_%06d.'+opt.tempimage_type,
-                opt.temp_dir+'/voice_tmp.mp3',
+                opt.temp_dir+'/voice_tmp.mkv',
                  os.path.join(opt.result_dir,os.path.splitext(os.path.basename(path))[0]+'_clean.mp4')) 

--- a/cores/init.py
+++ b/cores/init.py
@@ -21,7 +21,7 @@ def video_init(opt,path):
     
     print('Step:1/4 -- Convert video to images')
     util.file_init(opt)
-    ffmpeg.video2voice(path,opt.temp_dir+'/voice_tmp.mp3',opt.start_time,opt.last_time)
+    ffmpeg.video2voice(path,opt.temp_dir+'/voice_tmp.mkv',opt.start_time,opt.last_time)
     ffmpeg.video2image(path,opt.temp_dir+'/video2image/output_%06d.'+opt.tempimage_type,fps,opt.start_time,opt.last_time)
     imagepaths = os.listdir(opt.temp_dir+'/video2image')
     imagepaths.sort()

--- a/cores/style.py
+++ b/cores/style.py
@@ -47,4 +47,4 @@ def styletransfer_video(opt,netG):
     ffmpeg.image2video( fps,
                 opt.temp_dir+'/style_transfer/output_%06d.'+opt.tempimage_type,
                 opt.temp_dir+'/voice_tmp.mkv',
-                 os.path.join(opt.result_dir,os.path.splitext(os.path.basename(path))[0]+'_'+suffix+'.mp4')) 
+                 os.path.join(opt.result_dir,os.path.splitext(os.path.basename(path))[0]+'_'+suffix+'.mkv'))

--- a/cores/style.py
+++ b/cores/style.py
@@ -46,5 +46,5 @@ def styletransfer_video(opt,netG):
     print('Step:4/4 -- Convert images to video')
     ffmpeg.image2video( fps,
                 opt.temp_dir+'/style_transfer/output_%06d.'+opt.tempimage_type,
-                opt.temp_dir+'/voice_tmp.mp3',
+                opt.temp_dir+'/voice_tmp.mkv',
                  os.path.join(opt.result_dir,os.path.splitext(os.path.basename(path))[0]+'_'+suffix+'.mp4')) 

--- a/util/ffmpeg.py
+++ b/util/ffmpeg.py
@@ -53,7 +53,7 @@ def video2voice(videopath, voicepath, start_time='00:00:00', last_time='00:00:00
 def image2video(fps,imagepath,voicepath,videopath):
     os.system('ffmpeg -y -r '+str(fps)+' -i '+imagepath+' -vcodec libx264 '+os.path.split(voicepath)[0]+'/video_tmp.mp4')
     if os.path.exists(voicepath):
-        os.system('ffmpeg -i '+os.path.split(voicepath)[0]+'/video_tmp.mp4'+' -i "'+voicepath+'" -vcodec copy -acodec aac '+videopath)
+        os.system('ffmpeg -i '+os.path.split(voicepath)[0]+'/video_tmp.mp4'+' -i "'+voicepath+'" -c:v copy -c:a copy '+videopath)
     else:
         os.system('ffmpeg -i '+os.path.split(voicepath)[0]+'/video_tmp.mp4 '+videopath)
 

--- a/util/ffmpeg.py
+++ b/util/ffmpeg.py
@@ -43,7 +43,7 @@ def video2image(videopath, imagepath, fps=0, start_time='00:00:00', last_time='0
     run(args)
 
 def video2voice(videopath, voicepath, start_time='00:00:00', last_time='00:00:00'):
-    args = ['ffmpeg', '-i', '"'+videopath+'"','-async 1 -f mp3','-b:a 320k']
+    args = ['ffmpeg', '-i', '"'+videopath+'"','-async 1','-vn','-c:a copy']
     if last_time != '00:00:00':
         args += ['-ss', start_time]
         args += ['-t', last_time]


### PR DESCRIPTION
deepmosaic.py seperate audio into a tmp file and transcode it into mp3, then convert it back to aac with mp4.

It's not necessary, so we can use copy and matroska container format instead to prevent audio transcoding during process.